### PR TITLE
Features

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
-venv
+*venv*
 __pycache__
 dev_*
 config.yaml
-.TODO
+*TODO*
 *.log*
 Logs

--- a/Crypt.py
+++ b/Crypt.py
@@ -1024,11 +1024,18 @@ class MainWindow(QMainWindow, main_ui.Ui_MainWindow):
                 Logger.critical(str(e), exc_info=1)
             sys.exit(1)
         self.Plugins = functions.check_plugins(self.Plugins)
+        breakpoint()
+        _A = self.textBrowser.toMarkdown()
+        _A += "\n## Plugins\n"
 
         for i in self.Plugins:
             info = self.Plugins[i]().get_info()
             # info['name'] will be set as item data and can be used to call the plugin
             self.operationMode.addItem(info["config"]["display name"], info["name"])
+            # add plugin source URL, author, and license to About tab
+            _License = f""
+            _A += f"\n### {info['config']['display name']}\nby \"{info['author']}\""
+            self.textBrowser.setMarkdown(_A)
 
 
 if __name__ == "__main__":

--- a/Crypt.py
+++ b/Crypt.py
@@ -673,7 +673,8 @@ class MainWindow(QMainWindow, main_ui.Ui_MainWindow):
                     # Loading plugin info
                     t = self.Plugins[self.operationMode.currentData()]()
                     info = t.get_info()
-                    Logger.debug(f"Plugin info: {info}")
+                    _i = info.pop("license")
+                    Logger.debug(f"Plugin info: {_i}")
                     # Texts set to default and buttons enabled if supported by the plugin
                     self.btnEncode.setText(self.defaultTextEncode)
                     self.btnEncode.setEnabled(info["config"]["has encoder"])
@@ -698,6 +699,7 @@ class MainWindow(QMainWindow, main_ui.Ui_MainWindow):
                     self.inputRounds.setEnabled(info['config']['uses rounds'])
                     if info['config']['uses rounds']:
                         self.inputRounds.setText(str(info['config']['default rounds']))
+                    del info, _i, t
 
     def doDecode(self):
         input_data = self.inputText.toPlainText()
@@ -984,6 +986,12 @@ class MainWindow(QMainWindow, main_ui.Ui_MainWindow):
             results = t.brute_force(input_data, alphabet=alphabet, rounds=rounds)
             if results:
                 self.showMessageBox("Finished", "Decoded the input.", level=1, button=2)
+                if type(results) == dict:
+                    for i in results.items():
+                        p = self.outputText.toPlainText()
+                        self.outputText.setPlainText(f"{p}{i[0]}: {i[1]}\n")
+                else:
+                    self.outputText.setPlainText(results)
             Logger.debug(
                 f"{info['config']['display name']} Brute-forced: {input_data} -> {results}"
             )

--- a/Crypt.py
+++ b/Crypt.py
@@ -443,6 +443,8 @@ class MainWindow(QMainWindow, main_ui.Ui_MainWindow):
             "PBKDF2 SHA256",
             "PBKDF2 SHA512",
         )
+        # Replaces HTML about with Markdown version
+        self.textBrowser.setMarkdown(functions.getMarkdownAbout())
 
         # User settings
         settings = functions.load_settings()
@@ -1024,18 +1026,23 @@ class MainWindow(QMainWindow, main_ui.Ui_MainWindow):
                 Logger.critical(str(e), exc_info=1)
             sys.exit(1)
         self.Plugins = functions.check_plugins(self.Plugins)
-        breakpoint()
         _A = self.textBrowser.toMarkdown()
-        _A += "\n## Plugins\n"
+        _A += "## Plugins"
 
         for i in self.Plugins:
             info = self.Plugins[i]().get_info()
             # info['name'] will be set as item data and can be used to call the plugin
             self.operationMode.addItem(info["config"]["display name"], info["name"])
+
             # add plugin source URL, author, and license to About tab
-            _License = f""
-            _A += f"\n### {info['config']['display name']}\nby \"{info['author']}\""
+            try:
+                _URL = f"\n\nSource: {info['source url']}"
+            except KeyError:
+                _URL = ""
+            _LICENSE = f"\n\n{info['license']}"
+            _A += f"\n### {info['config']['display name']}{_URL}{_LICENSE}"
             self.textBrowser.setMarkdown(_A)
+        del _A, _URL, _LICENSE
 
 
 if __name__ == "__main__":

--- a/modules/functions.py
+++ b/modules/functions.py
@@ -182,10 +182,11 @@ def chKeySet(data: dict, key) -> None:
 
 def chKeyGood(data: dict, key, goal: object) -> None:
     if type(data[key]) != goal:
-        raise ValueError(f"`{key}` must be of type `{goal}`")
+        raise ValueError(f"`{key}` must be of type `{goal}`; It is `{type(data[key])}`")
 
 
 def checkConfig(data: dict) -> None:
+    """checks required variables in plugin info.yaml"""
     chKeySet(data, "name")
     chKeyGood(data, "name", str)
 
@@ -228,6 +229,9 @@ def checkConfig(data: dict) -> None:
     if data["config"]["uses rounds"]:
         chKeySet(data["config"], "default rounds")
 
+    chKeySet(data, "license")
+    chKeyGood(data, "license", str)
+
 
 def check_plugins(plugins: dict) -> dict:
     """Checks info.yaml file of all plugins and returns valid plugins"""
@@ -246,3 +250,35 @@ def check_plugins(plugins: dict) -> dict:
         plugins.pop(i)
 
     return plugins
+
+
+def getMarkdownAbout() -> str:
+    """Returns markdown version of About text"""
+    return """# About
+CRYPT GUI is licensed under GPL v3.0 Copyright (c) 2024 Ninja Left\n
+CRYPT was built using Python 3, Qt Designer & Pyside6.\n
+Some functions used in ciphers.py are from [This Repository](https://github.com/TheAlgorithms/Python) and are\n
+licensed under MIT Copyright (c) 2016-2024 TheAlgorithms and contributors.\n
+brute.py is a modified version of [brute](https://github.com/rdegges/brute)
+
+## Shortcuts:
+Ctrl + V : Paste\n
+Ctrl + = : Zoom In\n
+Ctrl + - : Zoom Out\n
+Ctrl + , : Settings\n
+Ctrl + B : Brute Force\n
+Ctrl + D : Decode\n
+Ctrl + E : Encode\n
+Ctrl + C : Copy
+
+## Icons credits:
+[Configure icon by afif fudin - Flaticon](https://www.flaticon.com/free-icon/configuration_9780271)\n
+[Login icon by FR_Media - Flaticon](https://www.flaticon.com/free-icon/login_5729989)\n
+[Logout icon by FR_Media - Flaticon](https://www.flaticon.com/free-icon/logout_5729988)\n
+[Locked icon by Aswell Studio - Flaticon](https://www.flaticon.com/free-icon/lock_2549910)\n
+[Unlocked icon by Aswell Studio - Flaticon](https://www.flaticon.com/free-icon/unlock_2549951)\n
+[Unsecure icon by juicy_fish - Flaticon](https://www.flaticon.com/free-icon/unsecure_5690981)\n
+[Search icon by Pixel Perfect - Flaticon](https://www.flaticon.com/free-icon/search_1828057)\n
+[Folder icon by Mehwish - Flaticon](https://www.flaticon.com/free-icon/folder_3307447)\n
+[Floppy disk icon by heisenberg_jr - Flaticon](https://www.flaticon.com/free-icon/floppy-disk_12629050)\n
+"""

--- a/modules/parent.py
+++ b/modules/parent.py
@@ -25,9 +25,9 @@ class Cipher(object):
         """
         return "decoded"
 
-    def brute_force(self, encoded, **kwargs):
+    def brute_force(self, encoded, **kwargs) -> str | dict:
         """
         **kwargs:
         alphabet, rounds
         """
-        return "decoded"
+        return {"keyX": "decoded"} or "decoded"

--- a/modules/plugins/Affine Cipher/affine_cipher.py
+++ b/modules/plugins/Affine Cipher/affine_cipher.py
@@ -3,8 +3,6 @@
 "gcd_by_iterative" from https://github.com/TheAlgorithms/Python/maths/greatest_common_divisor.py
 """
 
-import random
-import sys
 from ruamel.yaml import YAML
 from modules.parent import Cipher
 

--- a/modules/plugins/Affine Cipher/info.yaml
+++ b/modules/plugins/Affine Cipher/info.yaml
@@ -1,6 +1,29 @@
 name: 'affine'
 version: '1.0.0'
 requirements: ''
+source url: https://github.com/TheAlgorithms/Python/blob/master/ciphers/affine_cipher.py
+license: |-
+  #### MIT License
+
+  Copyright (c) 2016-2022 TheAlgorithms and contributors
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to deal
+  in the Software without restriction, including without limitation the rights
+  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in all
+  copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+  SOFTWARE.
 config:
   uses keys: true
   can change alphabet: true

--- a/modules/plugins/XOR cipher/info.yaml
+++ b/modules/plugins/XOR cipher/info.yaml
@@ -1,0 +1,38 @@
+name: 'xor'
+version: '1.1.0'
+requirements: ''
+source url: https://github.com/TheAlgorithms/Python/blob/master/ciphers/xor_cipher.py
+license: |-
+  #### MIT License
+
+  Copyright (c) 2016-2022 TheAlgorithms and contributors
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to deal
+  in the Software without restriction, including without limitation the rights
+  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in all
+  copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+  SOFTWARE.
+config:
+  can change alphabet: false
+  uses keys: true
+  default key: 128
+  display name: XOR Cipher
+  has encoder: true
+  has decoder: false
+  has brute: true
+  uses salt: false
+  uses plaintext: false
+  uses rounds: false
+

--- a/modules/plugins/XOR cipher/xor_cipher.py
+++ b/modules/plugins/XOR cipher/xor_cipher.py
@@ -1,0 +1,117 @@
+"""
+author: Christian Bender
+date: 21.12.2017
+class: XORCipher
+
+This class implements the XOR-cipher algorithm and provides
+some useful methods for encrypting and decrypting strings and
+files.
+
+Overview about methods
+
+- encode : str
+- decode : str
+- encode_file : boolean
+- decode_file : boolean
+"""
+
+from ruamel.yaml import YAML
+from modules.parent import Cipher
+
+y = YAML(typ="safe")
+with open("modules/plugins/XOR cipher/info.yaml") as f:
+    info = y.load(f)
+del y
+
+
+class BadKeyError(Exception):
+    def __init__(self, message: str = "Key is not valid"):
+        self.message = message
+        super().__init__(self.message)
+
+
+class XORCipher(Cipher):
+    global info
+    _alias_ = info["name"]
+    _version_ = info["version"]
+
+    def get_info(self) -> dict:
+        global info
+        return info
+
+    def encode(self, plain: str, **kwargs) -> str:
+        """
+        input: 'plain' of type string and 'key' of type int
+        output: encrypted string 'content'
+        """
+        try:
+            key = int(kwargs["key"])
+            # make sure key is an appropriate size
+            key %= 256
+        except ValueError:
+            raise BadKeyError("Key is not valid: Must be a number between 1-255")
+
+        ans = ""
+
+        for ch in plain:
+            ans += chr(ord(ch) ^ key)
+
+        return ans
+
+    def brute_force(self, plain, **kwargs) -> dict:
+        results = dict()
+        for i in range(1, 256):
+            results[f"Key {i}"] = self.encode(plain, key=i)
+        return results
+
+    # UNUSED
+    # def encode_file(self, file: str, out: str, key: int = 0) -> bool:
+    #     """
+    #     input: filename (str), output (str) and a key (int)
+    #     output: returns true if encrypt process was
+    #     successful otherwise false
+    #     """
+
+    #     # precondition
+    #     assert isinstance(file, str)
+    #     assert isinstance(key, int)
+
+    #     # make sure key is an appropriate size
+    #     key %= 256
+
+    #     try:
+    #         with open(file) as fin, open(out, "w+") as fout:
+    #             # actual encrypt-process
+    #             for line in fin:
+    #                 fout.write(self.encode(line, key))
+
+    #     except OSError:
+    #         return False
+
+    #     return True
+
+    # UNUSED
+    # def decode_file(self, file: str, out: str, key: int) -> bool:
+    #     """
+    #     input: filename (str), output (str) and a key (int)
+    #     output: returns true if decrypt process was
+    #     successful otherwise false
+    #     """
+
+    #     # precondition
+    #     assert isinstance(file, str)
+    #     assert isinstance(key, int)
+
+    #     # make sure key is an appropriate size
+    #     key %= 256
+
+    #     try:
+    #         with open(file) as fin, open(out, "w+") as fout:
+    #             # actual encrypt-process
+    #             for line in fin:
+    #                 fout.write(self.decode(line, key))
+
+    #     except OSError:
+    #         return False
+
+    #     return True

--- a/modules/plugins/a1z26/info.yaml
+++ b/modules/plugins/a1z26/info.yaml
@@ -5,8 +5,8 @@ version: '1.1.0'  # MUST SET
 # For example: 'Numpy,cffi,passlib,Pyside6'
 requirements: ''  # MUST SET
 source url: https://github.com/TheAlgorithms/Python/blob/master/ciphers/a1z26.py  # OPTIONAL; a URL to the original source code
-author: TheAlgorithms  # MUST SET
-license: | \### MIT License
+license: |-
+  #### MIT License
 
   Copyright (c) 2016-2022 TheAlgorithms and contributors
 
@@ -27,7 +27,7 @@ license: | \### MIT License
   LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
   OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
   SOFTWARE.
-# ^^^^^^ MUST SET; a short copyright notice; This will be displayed in About tab; Accept Markdown
+# ^^^^^^ MUST SET; a short copyright notice; This will be displayed in About tab under Plugins; Accepts Markdown
 config:
   uses keys: false  # MUST SET; If true, should also set a `default key` variable
   # default key: 0  # MUST SET (If above is set)

--- a/modules/plugins/a1z26/info.yaml
+++ b/modules/plugins/a1z26/info.yaml
@@ -4,11 +4,35 @@ version: '1.1.0'  # MUST SET
 # Modules should be coma (,) separated.
 # For example: 'Numpy,cffi,passlib,Pyside6'
 requirements: ''  # MUST SET
+source url: https://github.com/TheAlgorithms/Python/blob/master/ciphers/a1z26.py  # OPTIONAL; a URL to the original source code
+author: TheAlgorithms  # MUST SET
+license: | \### MIT License
+
+  Copyright (c) 2016-2022 TheAlgorithms and contributors
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to deal
+  in the Software without restriction, including without limitation the rights
+  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in all
+  copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+  SOFTWARE.
+# ^^^^^^ MUST SET; a short copyright notice; This will be displayed in About tab; Accept Markdown
 config:
   uses keys: false  # MUST SET; If true, should also set a `default key` variable
-  # default key: 0  # MUST SET
+  # default key: 0  # MUST SET (If above is set)
   can change alphabet: false  # MUST SET; If, true, should also set an `alphabet` variable
-  # alphabet: abc  # OPTIONAL
+  # alphabet: abc  # MUST SET (If above is set)
   display name: a1z26 cipher  # OPTIONAL; This will be shown to users. If not set, will use `name` instead.
   # The following 4 variables are MUST SET:
   has encoder: true  # true if plugin has encode function
@@ -18,4 +42,4 @@ config:
   # default pattern: 'SALT+PATTERN' # OPTIONAL; If not set, will read from user config
   uses plaintext: false  # MUST SET
   uses rounds: false  # MUST SET; If true, also set a `default rounds` variable
-  # default rounds: 0  # MUST SET
+  # default rounds: 0  # MUST SET (if above is set)


### PR DESCRIPTION
## Changes
- Plugin.brute_force now outputs results
- Added XOR cipher plugin (a simple brute forcer included)
- Removed unused imports from `affine cipher.py`
- Specified output type for `brute_force` in `parent.py`
- Added check for `license` key when checking plugins
- Added Plugin to About tab
- Added `license` & `source url` keys for plugins. Updated affine cipher info.yaml
- Corrected exclusion of TODO files. Included everything that has 'venv' in it's name to gitignore

Signed-off-by: Ninja Left <ninja.notleft@proton.me>